### PR TITLE
remove heroku, fix some styling

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: node app.js

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Two player tic-tac-toe online game.
 
 # How to Start a Game
 
-Go to https://twoplayer-tictactoe.herokuapp.com. 
+Go to https://tictactoe.lhernandezcruz.com.
 
 * First player clicks create game and sends GameID to other player. 
 * Second player enters the GameID in the input box and clicks enter

--- a/public/client.js
+++ b/public/client.js
@@ -32,7 +32,8 @@ $(document).ready(function () {
     socket.on('created', function (data) {
         // Show the GameID
         const url = window.location.href + "?gameId=" + data.id;
-        $("#status").html(`Send this link to other player: <p >${url}</p> `);
+        $("#status").html(`Send this link to other player:`);
+        $("#link").text(url);
     });
 
     // Called when join has a key entered
@@ -52,6 +53,7 @@ $(document).ready(function () {
         // hide remake and other items
         $("#remake").hide();
         $(".item").hide();
+        $('#link').hide();
 
         // Update game object
         game.id = data.id;

--- a/public/client.js
+++ b/public/client.js
@@ -34,6 +34,7 @@ $(document).ready(function () {
         const url = window.location.href + "?gameId=" + data.id;
         $("#status").html(`Send this link to other player:`);
         $("#link").text(url);
+        $('#link').show();
     });
 
     // Called when join has a key entered

--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,7 @@
     <div class="container text-center">
         <div class="status" id="status">
         </div>
+        <div class="link" id="link"></div>
         <div class="item title">Tic-Tac-Toe
         </div>
         <div class="item">

--- a/public/myCSS.css
+++ b/public/myCSS.css
@@ -27,7 +27,7 @@ body {
 } 
 
 .title { 
-    font-size: 65px; 
+    font-size: 45px; 
     font-family: 'Quicksand', sans-serif; 
     font-weight: bold; 
 } 
@@ -36,6 +36,10 @@ body {
     font-size: 50px; 
     font-family: 'Quicksand', sans-serif; 
 } 
+
+.link {
+    margin-top: 15px;
+}
 
 ol {
   text-align: left;


### PR DESCRIPTION
This contains a couple changes
1. update readme/instructions with new url
2. make it so tic tac toe text fits one line in landing page, fixes https://github.com/web-proyectos/tic-tac-toe/issues/13
3. fix game share url styling, fixes https://github.com/web-proyectos/tic-tac-toe/issues/10

Before:

![before](https://user-images.githubusercontent.com/19676254/194796181-f7ae98b7-e42c-48ff-849f-fd5a7918f473.PNG)


![link](https://user-images.githubusercontent.com/19676254/194796234-fb580ffb-f6fa-4f76-a5ff-711dff6beec5.PNG)

After:


https://user-images.githubusercontent.com/19676254/194796038-2c07227f-b5a5-4229-8945-dd5cfaef81c4.mp4


